### PR TITLE
Introduce type definitions + use built-in permutations function + remove some unnecessary statements

### DIFF
--- a/Revolution Rotation Calculator.py
+++ b/Revolution Rotation Calculator.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import itertools
+import math
 import sys
 import time
 from typing import List, Dict, Tuple
@@ -584,8 +585,8 @@ def main() -> None:
     best_rotation: List[str] = []
     worst_rotation: List[str] = []
     # --- Calculations for estimation of time remaining --- #
-    permutations: List[List[str]] = list(itertools.permutations(my_abilities))
-    time_remaining_calculation: int = int(len(permutations) / 10000)
+    permutation_count: int = math.factorial(len(my_abilities))
+    time_remaining_calculation: int = permutation_count / 10000
     runthrough: int = 0
     # --- Tracking of highest and lowest damaging ability bars  --- #
     current_highest: float = 0
@@ -615,7 +616,7 @@ def main() -> None:
     # --- Calculations start here --- #
     start: int = int(time.time())  # Record time since epoch (UTC) (in seconds)
     try:  # Will keep running until Control C (or other) is pressed to end process
-        for permutation in permutations:
+        for permutation in itertools.permutations(my_abilities):
             damage_dealt: float = ability_rotation(permutation)
             # --- Reset data ready for next ability bar to be tested
             # and check if any better/worse bars have been found --- #
@@ -639,7 +640,7 @@ def main() -> None:
             if runthrough == 10000:
                 end_estimation = int(time_remaining_calculation * (time.time() - start))
             if runthrough % 10000 == 0:
-                print(f"\r===== {round(float(runthrough / len(permutations)) * 100, 3)}"
+                print(f"\r===== {round(float(runthrough / permutation_count) * 100, 3)}"
                       f"% ===== Estimated time remaining: {get_time(int(end_estimation - (time.time() - start)))}"
                       f"; Best found: {current_highest}%" + (" " * 22), end="")
                 time_remaining_calculation -= 1

--- a/Revolution Rotation Calculator.py
+++ b/Revolution Rotation Calculator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import math
+import itertools
 import sys
 import time
 from typing import List, Dict, Tuple
@@ -571,18 +571,6 @@ def main() -> None:
                     aoe.remove(ability)
         return dict(ability_ready)
 
-    # Will generate an ability bar that has not been analysed yet
-    def get_permutation(my_list: List[str], index: int) -> List[str]:
-        new_list: List[str] = []
-        temp_list: List[str] = list(my_list)
-        denominator: int = len(temp_list)
-        while len(temp_list) > 0:
-            new_list.append(temp_list[index % denominator])
-            del temp_list[index % denominator]
-            index = int(index / denominator)
-            denominator -= 1
-        return new_list
-
     setup_config()
     # --- Dictionaries, lists and other data types laid out here --- #
     print("Starting process ...")
@@ -596,8 +584,8 @@ def main() -> None:
     best_rotation: List[str] = []
     worst_rotation: List[str] = []
     # --- Calculations for estimation of time remaining --- #
-    permutations: int = math.factorial(len(my_abilities))
-    time_remaining_calculation: int = int(permutations / 10000)
+    permutations: List[List[str]] = list(itertools.permutations(my_abilities))
+    time_remaining_calculation: int = int(len(permutations) / 10000)
     runthrough: int = 0
     # --- Tracking of highest and lowest damaging ability bars  --- #
     current_highest: float = 0
@@ -627,8 +615,7 @@ def main() -> None:
     # --- Calculations start here --- #
     start: int = int(time.time())  # Record time since epoch (UTC) (in seconds)
     try:  # Will keep running until Control C (or other) is pressed to end process
-        for index in range(0, permutations):
-            permutation = get_permutation(my_abilities, index)
+        for permutation in permutations:
             damage_dealt: float = ability_rotation(permutation)
             # --- Reset data ready for next ability bar to be tested
             # and check if any better/worse bars have been found --- #
@@ -652,7 +639,7 @@ def main() -> None:
             if runthrough == 10000:
                 end_estimation = int(time_remaining_calculation * (time.time() - start))
             if runthrough % 10000 == 0:
-                print(f"\r===== {round(float(runthrough / permutations) * 100, 3)}"
+                print(f"\r===== {round(float(runthrough / len(permutations)) * 100, 3)}"
                       f"% ===== Estimated time remaining: {get_time(int(end_estimation - (time.time() - start)))}"
                       f"; Best found: {current_highest}%" + (" " * 22), end="")
                 time_remaining_calculation -= 1

--- a/Revolution Rotation Calculator.py
+++ b/Revolution Rotation Calculator.py
@@ -2,159 +2,178 @@
 import math
 import sys
 import time
+from typing import List, Dict, Tuple
 
-abilities = ["ASPHYXIATE", "ASSAULT", "BACKHAND", "BARGE", "BERSERK", "BINDING SHOT", "BLOOD TENDRILS", "BOMBARDMENT",
-             "CHAIN", "CLEAVE", "COMBUST", "CONCENTRATED BLAST", "CORRUPTION BLAST", "CORRUPTION SHOT", "DAZING SHOT",
-             "DEADSHOT", "DEATH'S SWIFTNESS", "DEBILITATE", "DECIMATE", "DEEP IMPACT", "DESTROY", "DETONATE",
-             "DISMEMBER", "DRAGON BREATH", "FLURRY", "FORCEFUL BACKHAND", "FRAGMENTATION SHOT", "FRENZY", "FURY",
-             "HAVOC", "HURRICANE", "IMPACT", "KICK", "MASSACRE", "METAMORPHOSIS", "NEEDLE STRIKE", "OMNIPOWER",
-             "ONSLAUGHT", "OVERPOWER", "PIERCING SHOT", "PULVERISE", "PUNISH", "QUAKE", "RAPID FIRE", "RICOCHET",
-             "SACRIFICE", "SEVER", "SHADOW TENDRILS", "SHATTER", "SLAUGHTER", "SLICE", "SMASH", "SMOKE TENDRILS",
-             "SNAP SHOT", "SNIPE", "SONIC WAVE", "STOMP", "STORM SHARDS", "SUNSHINE", "TIGHT BINDINGS", "TSUNAMI",
-             "TUSKA'S WRATH", "UNLOAD", "WILD MAGIC", "WRACK"]
+abilities: List[str] = ["ASPHYXIATE", "ASSAULT", "BACKHAND", "BARGE", "BERSERK", "BINDING SHOT", "BLOOD TENDRILS",
+                        "BOMBARDMENT", "CHAIN", "CLEAVE", "COMBUST", "CONCENTRATED BLAST", "CORRUPTION BLAST",
+                        "CORRUPTION SHOT", "DAZING SHOT", "DEADSHOT", "DEATH'S SWIFTNESS", "DEBILITATE", "DECIMATE",
+                        "DEEP IMPACT", "DESTROY", "DETONATE", "DISMEMBER", "DRAGON BREATH", "FLURRY",
+                        "FORCEFUL BACKHAND", "FRAGMENTATION SHOT", "FRENZY", "FURY", "HAVOC", "HURRICANE", "IMPACT",
+                        "KICK", "MASSACRE", "METAMORPHOSIS", "NEEDLE STRIKE", "OMNIPOWER", "ONSLAUGHT", "OVERPOWER",
+                        "PIERCING SHOT", "PULVERISE", "PUNISH", "QUAKE", "RAPID FIRE", "RICOCHET", "SACRIFICE", "SEVER",
+                        "SHADOW TENDRILS", "SHATTER", "SLAUGHTER", "SLICE", "SMASH", "SMOKE TENDRILS", "SNAP SHOT",
+                        "SNIPE", "SONIC WAVE", "STOMP", "STORM SHARDS", "SUNSHINE", "TIGHT BINDINGS", "TSUNAMI",
+                        "TUSKA'S WRATH", "UNLOAD", "WILD MAGIC", "WRACK"]
 
 # --- Defining how abilities work --- #
 
 # Define cooldowns for cases where no abilities may be used
-attack_speed_cooldowns = {"FASTEST": 2.4, "FAST": 3.0, "AVERAGE": 3.6, "SLOW": 4.2, "SLOWEST": 7.2}
+attack_speed_cooldowns: Dict[str, float] = {"FASTEST": 2.4, "FAST": 3.0, "AVERAGE": 3.6, "SLOW": 4.2, "SLOWEST": 7.2}
 
 # Define ability damage for every ability
-ability_damage = {"ASPHYXIATE": 451.2, "ASSAULT": 525.6, "BACKHAND": 60, "BARGE": 75, "BERSERK": 0, "BINDING SHOT": 60,
-                  "BLOOD TENDRILS": 324, "BOMBARDMENT": 131.4, "CHAIN": 60, "CLEAVE": 112.8, "COMBUST": 241.2,
-                  "CONCENTRATED BLAST": 152.8, "CORRUPTION BLAST": 200, "CORRUPTION SHOT": 200, "DAZING SHOT": 94.2,
-                  "DEADSHOT": 426.13, "DEATH'S SWIFTNESS": 0, "DEBILITATE": 60, "DECIMATE": 112.8, "DEEP IMPACT": 120,
-                  "DESTROY": 451.2, "DETONATE": 225, "DISMEMBER": 120.6, "DRAGON BREATH": 112.8, "FLURRY": 204,
-                  "FORCEFUL BACKHAND": 120, "FRAGMENTATION SHOT": 120.6, "FRENZY": 610, "FURY": 152.8, "HAVOC": 94.2,
-                  "HURRICANE": 265, "IMPACT": 60, "KICK": 60, "MASSACRE": 426.13, "METAMORPHOSIS": 0,
-                  "NEEDLE STRIKE": 94.2, "OMNIPOWER": 300, "ONSLAUGHT": 532, "OVERPOWER": 300, "PIERCING SHOT": 56.4,
-                  "PULVERISE": 300, "PUNISH": 56.4, "QUAKE": 131.4, "RAPID FIRE": 451.2, "RICOCHET": 60,
-                  "SACRIFICE": 60, "SEVER": 112.8, "SHADOW TENDRILS": 283, "SHATTER": 0, "SLAUGHTER": 145, "SLICE": 75,
-                  "SMASH": 94.2, "SMOKE TENDRILS": 345, "SNAP SHOT": 265, "SNIPE": 172, "SONIC WAVE": 94.2,
-                  "STOMP": 120, "STORM SHARDS": 0, "SUNSHINE": 0, "TIGHT BINDINGS": 120, "TSUNAMI": 250,
-                  "TUSKA'S WRATH": 5940, "UNLOAD": 610, "WILD MAGIC": 265, "WRACK": 56.4}
+ability_damage: Dict[str, float] = {"ASPHYXIATE": 451.2, "ASSAULT": 525.6, "BACKHAND": 60, "BARGE": 75, "BERSERK": 0,
+                                    "BINDING SHOT": 60, "BLOOD TENDRILS": 324, "BOMBARDMENT": 131.4, "CHAIN": 60,
+                                    "CLEAVE": 112.8, "COMBUST": 241.2, "CONCENTRATED BLAST": 152.8,
+                                    "CORRUPTION BLAST": 200, "CORRUPTION SHOT": 200, "DAZING SHOT": 94.2,
+                                    "DEADSHOT": 426.13, "DEATH'S SWIFTNESS": 0, "DEBILITATE": 60, "DECIMATE": 112.8,
+                                    "DEEP IMPACT": 120, "DESTROY": 451.2, "DETONATE": 225, "DISMEMBER": 120.6,
+                                    "DRAGON BREATH": 112.8, "FLURRY": 204, "FORCEFUL BACKHAND": 120,
+                                    "FRAGMENTATION SHOT": 120.6, "FRENZY": 610, "FURY": 152.8, "HAVOC": 94.2,
+                                    "HURRICANE": 265, "IMPACT": 60, "KICK": 60, "MASSACRE": 426.13, "METAMORPHOSIS": 0,
+                                    "NEEDLE STRIKE": 94.2, "OMNIPOWER": 300, "ONSLAUGHT": 532, "OVERPOWER": 300,
+                                    "PIERCING SHOT": 56.4, "PULVERISE": 300, "PUNISH": 56.4, "QUAKE": 131.4,
+                                    "RAPID FIRE": 451.2, "RICOCHET": 60, "SACRIFICE": 60, "SEVER": 112.8,
+                                    "SHADOW TENDRILS": 283, "SHATTER": 0, "SLAUGHTER": 145, "SLICE": 75, "SMASH": 94.2,
+                                    "SMOKE TENDRILS": 345, "SNAP SHOT": 265, "SNIPE": 172, "SONIC WAVE": 94.2,
+                                    "STOMP": 120, "STORM SHARDS": 0, "SUNSHINE": 0, "TIGHT BINDINGS": 120,
+                                    "TSUNAMI": 250, "TUSKA'S WRATH": 5940, "UNLOAD": 610, "WILD MAGIC": 265,
+                                    "WRACK": 56.4}
 
 # Define the cooldown of abilities (in seconds)
-ability_cooldown = {"ASPHYXIATE": 20.4, "ASSAULT": 30, "BACKHAND": 15, "BARGE": 20.4, "BERSERK": 60, "BINDING SHOT": 15,
-                    "BLOOD TENDRILS": 45, "BOMBARDMENT": 30, "CHAIN": 10.2, "CLEAVE": 7.2, "COMBUST": 15,
-                    "CONCENTRATED BLAST": 5.4, "CORRUPTION BLAST": 15, "CORRUPTION SHOT": 15, "DAZING SHOT": 5.4,
-                    "DEADSHOT": 30, "DEATH'S SWIFTNESS": 60, "DEBILITATE": 30, "DECIMATE": 7.2, "DEEP IMPACT": 15,
-                    "DESTROY": 20.4, "DETONATE": 30, "DISMEMBER": 15, "DRAGON BREATH": 10.2, "FLURRY": 20.4,
-                    "FORCEFUL BACKHAND": 15, "FRAGMENTATION SHOT": 15, "FRENZY": 60, "FURY": 5.4, "HAVOC": 10.2,
-                    "HURRICANE": 20.4, "IMPACT": 15, "KICK": 15, "MASSACRE": 60, "METAMORPHOSIS": 60,
-                    "NEEDLE STRIKE": 5.4, "OMNIPOWER": 30, "ONSLAUGHT": 120, "OVERPOWER": 60, "PIERCING SHOT": 3,
-                    "PULVERISE": 60, "PUNISH": 3, "QUAKE": 20.4, "RAPID FIRE": 20.4, "RICOCHET": 10.2, "SACRIFICE": 30,
-                    "SEVER": 15, "SHADOW TENDRILS": 45, "SHATTER": 120, "SLAUGHTER": 30, "SLICE": 3, "SMASH": 10.2,
-                    "SMOKE TENDRILS": 45, "SNAP SHOT": 20.4, "SNIPE": 10.2, "SONIC WAVE": 5.4, "STOMP": 15,
-                    "STORM SHARDS": 30, "SUNSHINE": 60, "TIGHT BINDINGS": 15, "TSUNAMI": 60, "TUSKA'S WRATH": 120,
-                    "UNLOAD": 60, "WILD MAGIC": 20.4, "WRACK": 3}
+ability_cooldown: Dict[str, float] = {"ASPHYXIATE": 20.4, "ASSAULT": 30, "BACKHAND": 15, "BARGE": 20.4, "BERSERK": 60,
+                                      "BINDING SHOT": 15, "BLOOD TENDRILS": 45, "BOMBARDMENT": 30, "CHAIN": 10.2,
+                                      "CLEAVE": 7.2, "COMBUST": 15, "CONCENTRATED BLAST": 5.4, "CORRUPTION BLAST": 15,
+                                      "CORRUPTION SHOT": 15, "DAZING SHOT": 5.4, "DEADSHOT": 30,
+                                      "DEATH'S SWIFTNESS": 60, "DEBILITATE": 30, "DECIMATE": 7.2, "DEEP IMPACT": 15,
+                                      "DESTROY": 20.4, "DETONATE": 30, "DISMEMBER": 15, "DRAGON BREATH": 10.2,
+                                      "FLURRY": 20.4, "FORCEFUL BACKHAND": 15, "FRAGMENTATION SHOT": 15, "FRENZY": 60,
+                                      "FURY": 5.4, "HAVOC": 10.2, "HURRICANE": 20.4, "IMPACT": 15, "KICK": 15,
+                                      "MASSACRE": 60, "METAMORPHOSIS": 60, "NEEDLE STRIKE": 5.4, "OMNIPOWER": 30,
+                                      "ONSLAUGHT": 120, "OVERPOWER": 60, "PIERCING SHOT": 3, "PULVERISE": 60,
+                                      "PUNISH": 3, "QUAKE": 20.4, "RAPID FIRE": 20.4, "RICOCHET": 10.2, "SACRIFICE": 30,
+                                      "SEVER": 15, "SHADOW TENDRILS": 45, "SHATTER": 120, "SLAUGHTER": 30, "SLICE": 3,
+                                      "SMASH": 10.2, "SMOKE TENDRILS": 45, "SNAP SHOT": 20.4, "SNIPE": 10.2,
+                                      "SONIC WAVE": 5.4, "STOMP": 15, "STORM SHARDS": 30, "SUNSHINE": 60,
+                                      "TIGHT BINDINGS": 15, "TSUNAMI": 60, "TUSKA'S WRATH": 120, "UNLOAD": 60,
+                                      "WILD MAGIC": 20.4, "WRACK": 3}
 
 # How long it takes to use each ability
-ability_time = {"ASPHYXIATE": 5.4, "ASSAULT": 5.4, "BACKHAND": 1.8, "BARGE": 1.8, "BERSERK": 1.8, "BINDING SHOT": 1.8,
-                "BLOOD TENDRILS": 1.8, "BOMBARDMENT": 1.8, "CHAIN": 1.8, "CLEAVE": 1.8, "COMBUST": 1.8,
-                "CONCENTRATED BLAST": 3.6, "CORRUPTION BLAST": 1.8, "CORRUPTION SHOT": 1.8, "DAZING SHOT": 1.8,
-                "DEADSHOT": 1.8, "DEATH'S SWIFTNESS": 1.8, "DEBILITATE": 1.8, "DECIMATE": 1.8, "DEEP IMPACT": 1.8,
-                "DESTROY": 4.2, "DETONATE": 3.6, "DISMEMBER": 1.8, "DRAGON BREATH": 1.8, "FLURRY": 5.4,
-                "FORCEFUL BACKHAND": 1.8, "FRAGMENTATION SHOT": 1.8, "FRENZY": 4.2, "FURY": 3.6, "HAVOC": 1.8,
-                "HURRICANE": 1.8, "IMPACT": 1.8, "KICK": 1.8, "MASSACRE": 1.8, "METAMORPHOSIS": 1.8,
-                "NEEDLE STRIKE": 1.8, "OMNIPOWER": 1.8, "ONSLAUGHT": 4.8, "OVERPOWER": 1.8, "PIERCING SHOT": 1.8,
-                "PULVERISE": 1.8, "PUNISH": 1.8, "QUAKE": 1.8, "RAPID FIRE": 5.4, "RICOCHET": 1.8, "SACRIFICE": 1.8,
-                "SEVER": 1.8, "SHADOW TENDRILS": 1.8, "SHATTER": 1.8, "SLAUGHTER": 1.8, "SLICE": 1.8, "SMASH": 1.8,
-                "SMOKE TENDRILS": 5.4, "SNAP SHOT": 1.8, "SNIPE": 3.6, "SONIC WAVE": 1.8, "STOMP": 1.8,
-                "STORM SHARDS": 1.8, "SUNSHINE": 1.8, "TIGHT BINDINGS": 1.8, "TSUNAMI": 1.8, "TUSKA'S WRATH": 1.8,
-                "UNLOAD": 4.2, "WILD MAGIC": 4.8, "WRACK": 1.8}
+ability_time: Dict[str, float] = {"ASPHYXIATE": 5.4, "ASSAULT": 5.4, "BACKHAND": 1.8, "BARGE": 1.8, "BERSERK": 1.8,
+                                  "BINDING SHOT": 1.8, "BLOOD TENDRILS": 1.8, "BOMBARDMENT": 1.8, "CHAIN": 1.8,
+                                  "CLEAVE": 1.8, "COMBUST": 1.8, "CONCENTRATED BLAST": 3.6, "CORRUPTION BLAST": 1.8,
+                                  "CORRUPTION SHOT": 1.8, "DAZING SHOT": 1.8, "DEADSHOT": 1.8, "DEATH'S SWIFTNESS": 1.8,
+                                  "DEBILITATE": 1.8, "DECIMATE": 1.8, "DEEP IMPACT": 1.8, "DESTROY": 4.2,
+                                  "DETONATE": 3.6, "DISMEMBER": 1.8, "DRAGON BREATH": 1.8, "FLURRY": 5.4,
+                                  "FORCEFUL BACKHAND": 1.8, "FRAGMENTATION SHOT": 1.8, "FRENZY": 4.2, "FURY": 3.6,
+                                  "HAVOC": 1.8, "HURRICANE": 1.8, "IMPACT": 1.8, "KICK": 1.8, "MASSACRE": 1.8,
+                                  "METAMORPHOSIS": 1.8, "NEEDLE STRIKE": 1.8, "OMNIPOWER": 1.8, "ONSLAUGHT": 4.8,
+                                  "OVERPOWER": 1.8, "PIERCING SHOT": 1.8, "PULVERISE": 1.8, "PUNISH": 1.8, "QUAKE": 1.8,
+                                  "RAPID FIRE": 5.4, "RICOCHET": 1.8, "SACRIFICE": 1.8, "SEVER": 1.8,
+                                  "SHADOW TENDRILS": 1.8, "SHATTER": 1.8, "SLAUGHTER": 1.8, "SLICE": 1.8, "SMASH": 1.8,
+                                  "SMOKE TENDRILS": 5.4, "SNAP SHOT": 1.8, "SNIPE": 3.6, "SONIC WAVE": 1.8,
+                                  "STOMP": 1.8, "STORM SHARDS": 1.8, "SUNSHINE": 1.8, "TIGHT BINDINGS": 1.8,
+                                  "TSUNAMI": 1.8, "TUSKA'S WRATH": 1.8, "UNLOAD": 4.2, "WILD MAGIC": 4.8, "WRACK": 1.8}
 
 # Define the type of abilities (B = basic, T = threshold, U = ultimate)
-ability_type = {"ASPHYXIATE": "T", "ASSAULT": "T", "BACKHAND": "B", "BARGE": "B", "BERSERK": "U", "BINDING SHOT": "B",
-                "BLOOD TENDRILS": "T", "BOMBARDMENT": "T", "CHAIN": "B", "CLEAVE": "B", "COMBUST": "B",
-                "CONCENTRATED BLAST": "B", "CORRUPTION BLAST": "B", "CORRUPTION SHOT": "B", "DAZING SHOT": "B",
-                "DEADSHOT": "U", "DEATH'S SWIFTNESS": "U", "DEBILITATE": "T", "DECIMATE": "B", "DEEP IMPACT": "T",
-                "DESTROY": "T", "DETONATE": "T", "DISMEMBER": "B", "DRAGON BREATH": "B", "FLURRY": "T",
-                "FORCEFUL BACKHAND": "T", "FRAGMENTATION SHOT": "B", "FRENZY": "U", "FURY": "B", "HAVOC": "B",
-                "HURRICANE": "U", "IMPACT": "B", "KICK": "B", "MASSACRE": "U", "METAMORPHOSIS": "U",
-                "NEEDLE STRIKE": "B", "OMNIPOWER": "U", "ONSLAUGHT": "U", "OVERPOWER": "U", "PIERCING SHOT": "B",
-                "PULVERISE": "U", "PUNISH": "B", "QUAKE": "T", "RAPID FIRE": "T", "RICOCHET": "B", "SACRIFICE": "B",
-                "SEVER": "B", "SHADOW TENDRILS": "T", "SHATTER": "T", "SLAUGHTER": "T", "SLICE": "B", "SMASH": "B",
-                "SMOKE TENDRILS": "T", "SNAP SHOT": "T", "SNIPE": "B", "SONIC WAVE": "B", "STOMP": "T",
-                "STORM SHARDS": "B", "SUNSHINE": "U", "TIGHT BINDINGS": "T", "TSUNAMI": "U", "TUSKA'S WRATH": "B",
-                "UNLOAD": "U", "WILD MAGIC": "T", "WRACK": "B"}
+ability_type: Dict[str, str] = {"ASPHYXIATE": "T", "ASSAULT": "T", "BACKHAND": "B", "BARGE": "B", "BERSERK": "U",
+                                "BINDING SHOT": "B", "BLOOD TENDRILS": "T", "BOMBARDMENT": "T", "CHAIN": "B",
+                                "CLEAVE": "B", "COMBUST": "B", "CONCENTRATED BLAST": "B", "CORRUPTION BLAST": "B",
+                                "CORRUPTION SHOT": "B", "DAZING SHOT": "B", "DEADSHOT": "U", "DEATH'S SWIFTNESS": "U",
+                                "DEBILITATE": "T", "DECIMATE": "B", "DEEP IMPACT": "T", "DESTROY": "T", "DETONATE": "T",
+                                "DISMEMBER": "B", "DRAGON BREATH": "B", "FLURRY": "T", "FORCEFUL BACKHAND": "T",
+                                "FRAGMENTATION SHOT": "B", "FRENZY": "U", "FURY": "B", "HAVOC": "B", "HURRICANE": "U",
+                                "IMPACT": "B", "KICK": "B", "MASSACRE": "U", "METAMORPHOSIS": "U", "NEEDLE STRIKE": "B",
+                                "OMNIPOWER": "U", "ONSLAUGHT": "U", "OVERPOWER": "U", "PIERCING SHOT": "B",
+                                "PULVERISE": "U", "PUNISH": "B", "QUAKE": "T", "RAPID FIRE": "T", "RICOCHET": "B",
+                                "SACRIFICE": "B", "SEVER": "B", "SHADOW TENDRILS": "T", "SHATTER": "T",
+                                "SLAUGHTER": "T", "SLICE": "B", "SMASH": "B", "SMOKE TENDRILS": "T", "SNAP SHOT": "T",
+                                "SNIPE": "B", "SONIC WAVE": "B", "STOMP": "T", "STORM SHARDS": "B", "SUNSHINE": "U",
+                                "TIGHT BINDINGS": "T", "TSUNAMI": "U", "TUSKA'S WRATH": "B", "UNLOAD": "U",
+                                "WILD MAGIC": "T", "WRACK": "B"}
 
 # Define a flag to decide if you can use abilities (based on adrenaline)
-ability_ready = {"ASPHYXIATE": False, "ASSAULT": False, "BACKHAND": True, "BARGE": True, "BERSERK": False,
-                 "BINDING SHOT": True, "BLOOD TENDRILS": False, "BOMBARDMENT": False, "CHAIN": True, "CLEAVE": True,
-                 "COMBUST": True, "CONCENTRATED BLAST": True, "CORRUPTION BLAST": True, "CORRUPTION SHOT": True,
-                 "DAZING SHOT": True, "DEADSHOT": False, "DEATH'S SWIFTNESS": False, "DEBILITATE": False,
-                 "DECIMATE": True, "DEEP IMPACT": False, "DESTROY": False, "DETONATE": False, "DISMEMBER": True,
-                 "DRAGON BREATH": True, "FLURRY": False, "FORCEFUL BACKHAND": False, "FRAGMENTATION SHOT": True,
-                 "FRENZY": True, "FURY": True, "HAVOC": True, "HURRICANE": False, "IMPACT": True, "KICK": True,
-                 "MASSACRE": False, "METAMORPHOSIS": False, "NEEDLE STRIKE": True, "OMNIPOWER": False,
-                 "ONSLAUGHT": False, "OVERPOWER": False, "PIERCING SHOT": True, "PULVERISE": False, "PUNISH": True,
-                 "QUAKE": False, "RAPID FIRE": False, "RICOCHET": True, "SACRIFICE": True, "SEVER": True,
-                 "SHADOW TENDRILS": False, "SHATTER": False, "SLAUGHTER": False, "SLICE": True, "SMASH": True,
-                 "SMOKE TENDRILS": False, "SNAP SHOT": False, "SNIPE": True, "SONIC WAVE": True, "STOMP": False,
-                 "STORM SHARDS": True, "SUNSHINE": False, "TIGHT BINDINGS": False, "TSUNAMI": False,
-                 "TUSKA'S WRATH": True, "UNLOAD": False, "WILD MAGIC": False, "WRACK": True}
+ability_ready: Dict[str, bool] = {"ASPHYXIATE": False, "ASSAULT": False, "BACKHAND": True, "BARGE": True,
+                                  "BERSERK": False, "BINDING SHOT": True, "BLOOD TENDRILS": False, "BOMBARDMENT": False,
+                                  "CHAIN": True, "CLEAVE": True, "COMBUST": True, "CONCENTRATED BLAST": True,
+                                  "CORRUPTION BLAST": True, "CORRUPTION SHOT": True, "DAZING SHOT": True,
+                                  "DEADSHOT": False, "DEATH'S SWIFTNESS": False, "DEBILITATE": False, "DECIMATE": True,
+                                  "DEEP IMPACT": False, "DESTROY": False, "DETONATE": False, "DISMEMBER": True,
+                                  "DRAGON BREATH": True, "FLURRY": False, "FORCEFUL BACKHAND": False,
+                                  "FRAGMENTATION SHOT": True, "FRENZY": True, "FURY": True, "HAVOC": True,
+                                  "HURRICANE": False, "IMPACT": True, "KICK": True, "MASSACRE": False,
+                                  "METAMORPHOSIS": False, "NEEDLE STRIKE": True, "OMNIPOWER": False, "ONSLAUGHT": False,
+                                  "OVERPOWER": False, "PIERCING SHOT": True, "PULVERISE": False, "PUNISH": True,
+                                  "QUAKE": False, "RAPID FIRE": False, "RICOCHET": True, "SACRIFICE": True,
+                                  "SEVER": True, "SHADOW TENDRILS": False, "SHATTER": False, "SLAUGHTER": False,
+                                  "SLICE": True, "SMASH": True, "SMOKE TENDRILS": False, "SNAP SHOT": False,
+                                  "SNIPE": True, "SONIC WAVE": True, "STOMP": False, "STORM SHARDS": True,
+                                  "SUNSHINE": False, "TIGHT BINDINGS": False, "TSUNAMI": False, "TUSKA'S WRATH": True,
+                                  "UNLOAD": False, "WILD MAGIC": False, "WRACK": True}
 
 # Define the time DOT abilities last (in seconds)
-bleeds = {"BLOOD TENDRILS": 4.8, "COMBUST": 6, "CORRUPTION BLAST": 6, "CORRUPTION SHOT": 6, "DEADSHOT": 6,
-          "DISMEMBER": 6, "FRAGMENTATION SHOT": 6, "MASSACRE": 6, "SHADOW TENDRILS": 1.8, "SLAUGHTER": 6,
-          "SMOKE TENDRILS": 5.4}
+bleeds: Dict[str, float] = {"BLOOD TENDRILS": 4.8, "COMBUST": 6, "CORRUPTION BLAST": 6, "CORRUPTION SHOT": 6,
+                            "DEADSHOT": 6, "DISMEMBER": 6, "FRAGMENTATION SHOT": 6, "MASSACRE": 6,
+                            "SHADOW TENDRILS": 1.8, "SLAUGHTER": 6, "SMOKE TENDRILS": 5.4}
 
 # Define damage multiplier of walking bleeds
-walking_bleeds = {"COMBUST": 1, "FRAGMENTATION SHOT": 1, "SLAUGHTER": 1.5}
+walking_bleeds: Dict[str, float] = {"COMBUST": 1, "FRAGMENTATION SHOT": 1, "SLAUGHTER": 1.5}
 
 # Define bleed abilities that have their first hit affected by damage modifying abilities
-special_bleeds = ["DEADSHOT", "MASSACRE", "SMOKE TENDRILS"]
+special_bleeds: List[str] = ["DEADSHOT", "MASSACRE", "SMOKE TENDRILS"]
 
 # Define abilities that take longer than 1.8 seconds to use but will still have full impact from abilities in the
 # crit_boost list
-special_abilities = ["DETONATE", "SNIPE"]
+special_abilities: List[str] = ["DETONATE", "SNIPE"]
 
 # How long stuns, DPS increases .. etc last
-buff_time = {"BARGE": 6.6, "BERSERK": 19.8, "BINDING SHOT": 9.6, "CONCENTRATED BLAST": 5.4, "DEATH'S SWIFTNESS": 30,
-             "DEEP IMPACT": 3.6, "FORCEFUL BACKHAND": 3.6, "FURY": 5.4, "METAMORPHOSIS": 15, "NEEDLE STRIKE": 3.6,
-             "RAPID FIRE": 6, "STOMP": 3.6, "SUNSHINE": 30, "TIGHT BINDINGS": 9.6}
+buff_time: Dict[str, float] = {"BARGE": 6.6, "BERSERK": 19.8, "BINDING SHOT": 9.6, "CONCENTRATED BLAST": 5.4,
+                               "DEATH'S SWIFTNESS": 30, "DEEP IMPACT": 3.6, "FORCEFUL BACKHAND": 3.6, "FURY": 5.4,
+                               "METAMORPHOSIS": 15, "NEEDLE STRIKE": 3.6, "RAPID FIRE": 6, "STOMP": 3.6, "SUNSHINE": 30,
+                               "TIGHT BINDINGS": 9.6}
 
 # Define the Multiplier for boosted damage
-buff_effect = {"BERSERK": 2, "CONCENTRATED BLAST": 1.1, "DEATH'S SWIFTNESS": 1.5, "FURY": 1.1, "METAMORPHOSIS": 1.625,
-               "NEEDLE STRIKE": 1.07, "PIERCING SHOT": 2, "PUNISH": 2, "SLICE": 1.506, "SUNSHINE": 1.5, "WRACK": 2}
+buff_effect: Dict[str, float] = {"BERSERK": 2, "CONCENTRATED BLAST": 1.1, "DEATH'S SWIFTNESS": 1.5, "FURY": 1.1,
+                                 "METAMORPHOSIS": 1.625, "NEEDLE STRIKE": 1.07, "PIERCING SHOT": 2, "PUNISH": 2,
+                                 "SLICE": 1.506, "SUNSHINE": 1.5, "WRACK": 2}
 
 # Define crit-boosting abilities
-crit_boost = ["BERSERK", "CONCENTRATED BLAST", "DEATH'S SWIFTNESS", "FURY", "METAMORPHOSIS", "NEEDLE STRIKE",
-              "SUNSHINE"]
+crit_boost: List[str] = ["BERSERK", "CONCENTRATED BLAST", "DEATH'S SWIFTNESS", "FURY", "METAMORPHOSIS", "NEEDLE STRIKE",
+                         "SUNSHINE"]
 
 # Define the abilities that do extra damage when the target is stun or bound
-punishing = ["PIERCING SHOT", "PUNISH", "SLICE", "WRACK"]
+punishing: List[str] = ["PIERCING SHOT", "PUNISH", "SLICE", "WRACK"]
 
 # Define abilities that can stun or bind the target
-debilitating = ["BARGE", "BINDING SHOT", "DEEP IMPACT", "FORCEFUL BACKHAND", "RAPID FIRE", "STOMP", "TIGHT BINDINGS"]
+debilitating: List[str] = ["BARGE", "BINDING SHOT", "DEEP IMPACT", "FORCEFUL BACKHAND", "RAPID FIRE", "STOMP",
+                           "TIGHT BINDINGS"]
 
 # Define abilities that bind the target
-binds = ["BARGE", "BINDING SHOT", "DEEP IMPACT", "TIGHT BINDINGS"]
+binds: List[str] = ["BARGE", "BINDING SHOT", "DEEP IMPACT", "TIGHT BINDINGS"]
 
 # Define area of effect abilities
-aoe = ["BOMBARDMENT", "CHAIN", "CLEAVE", "CORRUPTION BLAST", "CORRUPTION SHOT", "DRAGON BREATH", "FLURRY", "HURRICANE",
-       "QUAKE", "RICOCHET", "TSUNAMI"]
+aoe: List[str] = ["BOMBARDMENT", "CHAIN", "CLEAVE", "CORRUPTION BLAST", "CORRUPTION SHOT", "DRAGON BREATH", "FLURRY",
+                  "HURRICANE", "QUAKE", "RICOCHET", "TSUNAMI"]
 
-start_adrenaline = 0
-gain = 0
-attack_speed: ""
-activate_bleeds = False
-my_abilities = []
-auto_adrenaline = 0
-cycle_duration = 0
+start_adrenaline: int
+gain: int
+attack_speed: str
+activate_bleeds: bool
+my_abilities: List[str]
+auto_adrenaline: int
+cycle_duration: float
 
 
 # Will return how much damage an ability bar will do over a given time
-def ability_rotation(permutation):
+def ability_rotation(permutation: List[str]) -> float:
     # Will check if an auto attack is needed to be used
-    def auto_available():
+    def auto_available() -> bool:
         for ability in track_cooldown:
             if (ability_cooldown[ability] - track_cooldown[ability]) < attack_speed_cooldowns[attack_speed]:
                 return False
         return True
 
     # Decreases Cooldowns of abilities and buffs as well as modifying and damage multipliers
-    def adjust_cooldowns(current_buff, adrenaline, cooldown_time):
+    def adjust_cooldowns(current_buff: float, adrenaline: int, cooldown_time: float) -> float:
         for ability in track_cooldown:
             track_cooldown[ability] += cooldown_time
             track_cooldown[ability] = round(track_cooldown[ability], 1)
@@ -184,13 +203,13 @@ def ability_rotation(permutation):
         return current_buff
 
     # Determines if enemy vulnerable to extra damage due to stuns or binds
-    def buff_available():
+    def buff_available() -> bool:
         for ability in debilitating:
             if ability in track_buff:
                 return True
         return False
 
-    def modify_time(cycle_duration, time_elapsed, ability):
+    def modify_time(cycle_duration: float, time_elapsed: float, ability: str) -> float:
         if (ability in bleeds) and (ability != "SHADOW TENDRILS") and (
                     (cycle_duration - time_elapsed) < bleeds[ability]):
             return (cycle_duration - time_elapsed) / bleeds[ability]
@@ -201,11 +220,10 @@ def ability_rotation(permutation):
         return 1
 
     # --- Defining Variables --- #
-    altered_bleeds = False
-    damage_dealt = 0
-    current_buff = float(1)
-    time_elapsed = 0
-    shards = 0
+    damage_dealt: float = 0
+    current_buff: float = 1
+    time_elapsed: float = 0
+    shards: float = 0
     adrenaline = start_adrenaline
     # --- Calculations begin here --- #
     ability_path.append(f"AUTO D: {round(damage_dealt, 1)} T: {round(time_elapsed, 1)} A: {adrenaline}")
@@ -248,11 +266,11 @@ def ability_rotation(permutation):
                     damage_dealt += round(shards * 85, 1)
                     shards = 0
                     # --- Calculating how much damage abilities should do --- #
-                more_binds = False
-                altered_bleeds = False
-                modified_damage = False
-                damage_multiplier = float(1)  # Multiplier for damage due to damage boosting abilities
-                bleed_multiplier = float(1)  # Multiplier in case target is bound (and bind about to run out)
+                more_binds: bool = False
+                altered_bleeds: bool = False
+                modified_damage: bool = False
+                damage_multiplier: float = 1  # Multiplier for damage due to damage boosting abilities
+                bleed_multiplier: float = 1  # Multiplier in case target is bound (and bind about to run out)
                 for tracked_ability in track_buff:
                     if tracked_ability in crit_boost:
                         if ((buff_time[tracked_ability] - track_buff[tracked_ability]) < ability_time[ability]) and (
@@ -274,7 +292,6 @@ def ability_rotation(permutation):
                         altered_bleeds = True
                 if (activate_bleeds is True) and (ability in walking_bleeds) and (altered_bleeds is False):
                     bleed_multiplier = walking_bleeds[ability] * 2
-                altered_bleeds = False
                 time_multiplier = modify_time(cycle_duration, time_elapsed, ability)
                 if ability in bleeds:
                     if ability in special_bleeds:
@@ -286,7 +303,6 @@ def ability_rotation(permutation):
                     damage_dealt += round(ability_damage[ability] * bleed_multiplier * time_multiplier, 1)
                     if modified_damage is True:
                         ability_damage[ability] = 426.13
-                        modified_damage = False
                 elif (ability in punishing) and (buff_available() is True):
                     damage_dealt += round(ability_damage[ability] * buff_effect[ability] * damage_multiplier *
                                           time_multiplier, 1)
@@ -352,21 +368,21 @@ def ability_rotation(permutation):
     return damage_dealt
 
 
-def setup_config():
+def setup_config() -> None:
     global start_adrenaline, gain, attack_speed, activate_bleeds, debilitating, my_abilities, auto_adrenaline, cycle_duration
 
-    def compare(lines):
+    def compare(lines) -> bool:
         # configuration followed by line number
-        correct_data = {"Adrenaline": 2, "Gain": 3, "AttackSpeed": 4, "Bleeds": 5, "Stuns": 6, "Abilities": 7,
-                        "Style": 8, "Time": 9, "units": 13}
+        correct_data: Dict[str, int] = {"Adrenaline": 2, "Gain": 3, "AttackSpeed": 4, "Bleeds": 5, "Stuns": 6,
+                                        "Abilities": 7, "Style": 8, "Time": 9, "units": 13}
         for setting in correct_data:
             if setting != lines[correct_data[setting]]:
                 return False
         return True
 
-    def validate(configurations):
-        error_log = []
-        empty_field = False
+    def validate(configurations) -> List[str]:
+        error_log: List[str] = []
+        empty_field: bool = False
         for config in configurations:
             if config == "":
                 empty_field = True
@@ -374,14 +390,14 @@ def setup_config():
             error_log.append("One or more settings have been left empty.")
 
         try:
-            setting = int(configurations[0])
+            setting: int = int(configurations[0])
             if not (0 <= setting <= 100):
                 error_log.append("Adrenaline must be between 0 and 100 inclusive.")
         except ValueError:
             error_log.append("Adrenaline must be an integer.")
 
         try:
-            setting = int(configurations[1])
+            setting: int = int(configurations[1])
             if not (0 <= setting <= 100):
                 error_log.append("Gain must be a positive integer between 0 and 100 inclusive.")
         except ValueError:
@@ -391,18 +407,18 @@ def setup_config():
             error_log.append("AttackSpeed must either be one of the following options: ('slowest, slow, average, fast,"
                              " fastest').")
 
-        setting = configurations[3]
+        setting: str = configurations[3]
         if not ((setting.lower() == "false") or (setting.lower() == "true")):
             error_log.append("Bleeds must be true or false.")
 
-        setting = configurations[4]
+        setting: str = configurations[4]
         if not ((setting.lower() == "false") or (setting.lower() == "true")):
             error_log.append("Stuns must be true or false.")
 
-        setting = configurations[5]
+        setting: str = configurations[5]
         if setting[0] == "[" and setting[-1] == "]":
             setting = setting[1:-1].split(",")
-            counter = {}
+            counter: Dict[str, int] = {}
             if len(setting) > 0:
                 for ability in setting:
                     ability = ability.upper().strip()
@@ -412,9 +428,8 @@ def setup_config():
                     if ability in counter:
                         counter[ability] += 1
                         if counter[ability] == 2:
-                            error_log.append(
-                                f"{(ability.strip())} is referenced 2 or more times within array. Ensure it "
-                                f"is only referenced once.")
+                            error_log.append(f"{(ability.strip())} is referenced 2 or more times within array. Ensure "
+                                             f"it is only referenced once.")
                     else:
                         counter[ability] = 1
             else:
@@ -422,7 +437,7 @@ def setup_config():
         else:
             error_log.append("Abilities must be surrounded by square brackets [], and separated by comma's (,).")
 
-        setting = configurations[6]
+        setting: str = configurations[6]
         if setting[0] == "(" and setting[-1] == ")":
             setting = setting[1:-1].split(",")
             if setting[0].upper() not in ("MAGIC", "RANGED", "MELEE"):
@@ -434,7 +449,7 @@ def setup_config():
                              "comma (,).")
 
         try:
-            setting = float(configurations[7])
+            setting: float = float(configurations[7])
             if not (setting > 0):
                 error_log.append("Time must be a number greater than zero.")
         except ValueError:
@@ -445,13 +460,13 @@ def setup_config():
 
         return error_log
 
-    def repair_config_file():
-        repair = input("Configurations.txt has been modified, perform repair? (Y/N).\n>> ").upper()
+    def repair_config_file() -> None:
+        repair: str = input("Configurations.txt has been modified, perform repair? (Y/N).\n>> ").upper()
         if (repair == "Y") or (repair == "YES"):
             import os
-            correct_data = ["# Rotation Parameters", "", "Adrenaline: ", "Gain: ", "AttackSpeed: ", "Bleeds: ",
-                            "Stuns: ",
-                            "Abilities: [,,,]", "Style: (,)", "Time: ", "", "# Mode", "", "units: seconds"]
+            correct_data: List[str] = ["# Rotation Parameters", "", "Adrenaline: ", "Gain: ", "AttackSpeed: ",
+                                       "Bleeds: ", "Stuns: ", "Abilities: [,,,]", "Style: (,)", "Time: ", "", "# Mode",
+                                       "", "units: seconds"]
             if os.path.exists("Configurations.txt"):
                 os.remove("Configurations.txt")
             with open("Configurations.txt", "w") as settings:
@@ -462,8 +477,8 @@ def setup_config():
         sys.exit()
 
     # --- Gets data for setup  --- #
-    filedata = []
-    configurations = []
+    filedata: List[str] = []
+    configurations: List[str] = []
     try:
         with open("Configurations.txt", "r") as settings:
             for line in settings:
@@ -486,14 +501,14 @@ def setup_config():
     gain = int(configurations[1])
     attack_speed = configurations[2].upper()
     activate_bleeds = configurations[3]
-    bound = configurations[4]
+    bound: str = configurations[4]
     if bound == "False":
         debilitating = []
     my_abilities = []
     for ability in configurations[5][1:-1].split(","):
         my_abilities.append(ability.strip().upper())
     # --- Different styles of combat tree give varying amounts of adrenaline from auto attacks --- #
-    style = tuple(configurations[6][1:-1].split(","))
+    style: Tuple[str, str] = tuple(configurations[6][1:-1].split(","))
     if style[0] == "MAGIC":
         auto_adrenaline = 2
     else:
@@ -502,31 +517,31 @@ def setup_config():
         else:
             auto_adrenaline = 3
     cycle_duration = float(configurations[7])
-    units = configurations[8]
+    units: str = configurations[8]
     if units == "ticks":
         cycle_duration *= 0.6
 
 
-def main():
+def main() -> None:
     global basic_ability_list, threshold_ability_list, ultimate_ability_list, track_cooldown, track_buff, ability_path, ability_ready
 
     # Converts raw seconds into Years, Weeks, etc...
-    def get_time(seconds):
-        years = int(seconds / 31449600)
+    def get_time(seconds: int) -> str:
+        years: int = int(seconds / 31449600)
         seconds -= years * 31449600
-        weeks = int(seconds / 604800)
+        weeks: int = int(seconds / 604800)
         seconds -= weeks * 604800
-        days = int(seconds / 86400)
+        days: int = int(seconds / 86400)
         seconds -= days * 86400
-        hours = int(seconds / 3600)
+        hours: int = int(seconds / 3600)
         seconds -= hours * 3600
-        minutes = int(seconds / 60)
+        minutes: int = int(seconds / 60)
         seconds -= minutes * 60
-        eta = f"{years} years, {weeks} weeks, {days} days, {hours} hours, {minutes} minutes and {seconds} seconds."
+        eta: str = f"{years} years, {weeks} weeks, {days} days, {hours} hours, {minutes} minutes and {seconds} seconds."
         return eta
 
     # Removes abilities from lists and dictionaries not being used to save runtime and memory
-    def remove(copy_of_ready):
+    def remove() -> Dict[str, bool]:
         for ability in abilities:
             if not (ability in my_abilities):
                 del ability_damage[ability]
@@ -557,10 +572,10 @@ def main():
         return dict(ability_ready)
 
     # Will generate an ability bar that has not been analysed yet
-    def get_permutation(my_list, index):
-        new_list = []
-        temp_list = list(my_list)
-        denominator = len(temp_list)
+    def get_permutation(my_list: List[str], index: int) -> List[str]:
+        new_list: List[str] = []
+        temp_list: List[str] = list(my_list)
+        denominator: int = len(temp_list)
         while len(temp_list) > 0:
             new_list.append(temp_list[index % denominator])
             del temp_list[index % denominator]
@@ -571,25 +586,24 @@ def main():
     setup_config()
     # --- Dictionaries, lists and other data types laid out here --- #
     print("Starting process ...")
-    copy_of_ready = {}
-    copy_of_ready = remove(copy_of_ready)
+    copy_of_ready = remove()
     basic_ability_list = [a for a in ability_type if ability_type[a] == "B"]
     threshold_ability_list = [a for a in ability_type if ability_type[a] == "T"]
     ultimate_ability_list = [a for a in ability_type if ability_type[a] == "U"]
     track_cooldown = {}
     track_buff = {}
     ability_path = []
-    best_rotation = []
-    worst_rotation = []
+    best_rotation: List[str] = []
+    worst_rotation: List[str] = []
     # --- Calculations for estimation of time remaining --- #
-    permutations = math.factorial(len(my_abilities))
-    time_remaining_calculation = int(permutations / 10000)
-    runthrough = int(0)
+    permutations: int = math.factorial(len(my_abilities))
+    time_remaining_calculation: int = int(permutations / 10000)
+    runthrough: int = 0
     # --- Tracking of highest and lowest damaging ability bars  --- #
-    current_highest = float(0)
-    current_lowest = float("inf")
+    current_highest: float = 0
+    current_lowest: float = float("inf")
     # Define the amount of targets affected by area of effect attacks
-    aoe_average_targets_hit = 2.5
+    aoe_average_targets_hit: float = 2.5
     # --- Gets rotation length --- #
     while True:
         try:
@@ -607,15 +621,15 @@ def main():
                 ability_damage[ability] = ability_damage[ability] * aoe_average_targets_hit
     print("Startup Complete! Warning, the more the abilities, and the higher the cycle time, the more time it will take"
           " to process. A better processor will improve this speed.")
-    choice = input("Start Calculations? (Y/N) ").upper()
+    choice: str = input("Start Calculations? (Y/N) ").upper()
     if (choice != "Y") and (choice != "YES"):
         sys.exit()
     # --- Calculations start here --- #
-    start = int(time.time())  # Record time since epoch (UTC) (in seconds)
+    start: int = int(time.time())  # Record time since epoch (UTC) (in seconds)
     try:  # Will keep running until Control C (or other) is pressed to end process
         for index in range(0, permutations):
             permutation = get_permutation(my_abilities, index)
-            damage_dealt = ability_rotation(permutation)
+            damage_dealt: float = ability_rotation(permutation)
             # --- Reset data ready for next ability bar to be tested
             # and check if any better/worse bars have been found --- #
             ability_ready = dict(copy_of_ready)
@@ -625,12 +639,12 @@ def main():
                 current_highest = round(damage_dealt, 1)
                 best_rotation = []
                 best_rotation = list(ability_path)
-                best_bar = list(permutation)
+                best_bar: List[str] = list(permutation)
                 print(f"New best bar with damage {current_highest}: {best_bar}")
             if round(damage_dealt, 1) < current_lowest:
                 current_lowest = round(damage_dealt, 1)
-                worst_rotation = []
-                worst_rotation = list(ability_path)
+                worst_rotation: List[str] = []
+                worst_rotation: List[str] = list(ability_path)
                 worst_bar = list(permutation)
             ability_path = []
             runthrough += 1


### PR DESCRIPTION

Text borrowed from this answer 🙂: https://stackoverflow.com/questions/32557920/what-are-type-hints-in-python-3-5
# Why Type Hints?

1. **Helps Type Checkers:** By hinting at what type you want the object to be the type checker can easily detect if, for instance, you're passing an object with a type that isn't expected.
2. **Helps with documentation:** A third person viewing your code will know what is expected where, ergo, how to use it without getting them `TypeErrors`.
3. **Helps IDEs develop more accurate and robust tools:** Development Environments will be better suited at suggesting appropriate methods when know what type your object is. You have probably experienced this with some IDE at some point, hitting the `.` and having methods/attributes pop up which aren't defined for an object.
# Why use Static Type Checkers?

**Find bugs sooner:** This is self evident, I believe.
**The larger your project the more you need it:** Again, makes sense. Static languages offer a robustness and control that dynamic languages lack. The bigger and more complex your application becomes the more control and predictability (from a behavioral aspect) you require.
**Large teams are already running static analysis:** I'm guessing this verifies the first two points.